### PR TITLE
chore: Replace pbench support in the pig wrapper with PCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ General options
   --home_parent <value>: Our parent home directory.  If not set, defaults to current working directory.
   --host_config <value>: default is the current host name.
   --iterations <value>: Number of times to run the test, defaults to 1.
-  --pbench: use pbench-user-benchmark and place information into pbench, defaults to do not use.
-  --pbench_user <value>: user who started everything. Defaults to the current user.
-  --pbench_copy: Copy the pbench data, not move it.
-  --pbench_stats: What stats to gather. Defaults to all stats.
-  --run_label: the label to associate with the pbench run. No default setting.
   --run_user: user that is actually running the test on the test system. Defaults to user running wrapper.
   --sys_type: Type of system working with, aws, azure, hostname.  Defaults to hostname.
   --sysname: name of the system running, used in determing config files.  Defaults to hostname.
@@ -33,5 +28,3 @@ General options
     RHEL systems, default is none.
   --usage: this usage message.
 ```
-
-Note: The script does not install pbench for you.  You need to do that manually.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Options
   --pig_opts: options to pass directly to pig
   --regression: If present, we run a limted pig test. 8 points, 120 seconds each point
   --tools_git: Pointer to the test_tools git.  Default is https://github.com/dvalinrh/test_tools.  Top directory is always test_tools
+  --use_pcp: Enables use of Performance Co-Pilot in wrappers, defaults to 0.
 General options
   --home_parent <value>: Our parent home directory.  If not set, defaults to current working directory.
   --host_config <value>: default is the current host name.

--- a/pig/run_pig
+++ b/pig/run_pig
@@ -56,7 +56,7 @@ obtain_system_information()
 	numb_cpus=`echo $cpus - 2 | bc`
 
 	RESULTSDIR=results_pig_${tuned_setting}_$(date "+%Y.%m.%d-%H.%M.%S")
-	rm results_pig_${tuned_setting}
+	rm -rf results_pig_${tuned_setting}
 	mkdir ${RESULTSDIR}
 	cp -R  ${RESULTSDIR} results_pig_${tuned_setting}
 

--- a/pig/run_pig.sh
+++ b/pig/run_pig.sh
@@ -98,6 +98,7 @@ fi
 # to_sys_type: for results info, basically aws, azure or local
 # to_sysname: name of the system
 # to_tuned_setting: tuned setting
+# to_use_pcp: flag to indicate if pcp should be used
 #
 
 source test_tools/general_setup "$@"
@@ -157,7 +158,7 @@ shift $((OPTIND-1))
 #
 produce_results_info()
 {
-	grep -H "#CPUS:" iteration*  | cut -d: -f 4,5 | sed "s/  / /g" | cut -d' ' -f 2,4 | sort -n -k2 > temp_data
+	grep -H "#CPUS:" iteration* | cut -d: -f 4,5 | sed "s/  / /g" | cut -d' ' -f 2,4 | sort -n -k2 > temp_data
 
 	if [[ -f results_${test_name}.csv ]]; then
 		rm results_${test_name}.csv > /dev/null
@@ -239,13 +240,28 @@ run_pig_test()
 			packages="$packages,numactl-devel,numactl-libs"
 		;;
 	esac
+	echo "test_tools/package_tool --packages $packages --no_packages $to_no_pkg_install" > /tmp/pi_debug
 	test_tools/package_tool --packages $packages --no_packages $to_no_pkg_install
 
+
+	# Get PCP setup if we're using it
+	if [[ $to_use_pcp -eq 1 ]]; then
+	    	source $TOOLS_BIN/pcp/pcp_commands.inc
+	    	setup_pcp
+	    	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+		pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
+	fi
 
 	#
 	# Check to see if we have a parameters file to use.
 	#
 	file=`${curdir}/tools_bin/get_params_file -d /$to_home_root/${to_user} -c ${config_name} -t ${test_name}`
+
+	# If we're using PCP start logging
+	if [[ $to_use_pcp -eq 1 ]]; then
+	        echo "Start PCP"
+	       	start_pcp ${pcpdir}/ ${test_name} $pcp_cfg
+	fi
 
 	if test -f "$file"; then
 		#
@@ -261,6 +277,18 @@ run_pig_test()
 		#
 		run_pig_test 
 	fi
+
+	# If we're using PCP, stop logging
+	if [[ $to_use_pcp -eq 1 ]]; then
+	        echo "Stop PCP"
+	        stop_pcp
+	fi
+	
+	# Shutdown PCP and clean up after ourselves
+	if [[ $to_use_pcp -eq 1 ]]; then
+	    	shutdown_pcp
+	fi
+	
 	cd $run_dir
 	cd results_${test_name}_${to_tuned_setting} 
 	produce_results_info
@@ -268,4 +296,7 @@ run_pig_test()
 	#
 	# Save the results for later.
 	#
+	if [[ $to_use_pcp -eq 1 ]]; then
+		cp -R ${pcpdir} results_${test_name}_${to_tuned_setting}
+	fi
 	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir results_${test_name}_${to_tuned_setting} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user

--- a/pig/run_pig.sh
+++ b/pig/run_pig.sh
@@ -228,75 +228,74 @@ run_pig_test()
 	popd > /dev/null
 }
 
-	# Ensure required packages are installed for compilation/linking
+# Ensure required packages are installed for compilation/linking
+#
+os="`test_tools/detect_os`"
+packages="gcc"
+case "$os" in
+	"ubuntu")
+		packages="$packages,libnuma-dev"
+	;;
+	*) # RHEL based systems
+		packages="$packages,numactl-devel,numactl-libs"
+	;;
+esac
+echo "test_tools/package_tool --packages $packages --no_packages $to_no_pkg_install" > /tmp/pi_debug
+test_tools/package_tool --packages $packages --no_packages $to_no_pkg_install
+
+# Get PCP setup if we're using it
+if [[ $to_use_pcp -eq 1 ]]; then
+	source $TOOLS_BIN/pcp/pcp_commands.inc
+	setup_pcp
+	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+	pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
+fi
+
+#
+# Check to see if we have a parameters file to use.
+#
+file=`${TOOLS_BIN}/get_params_file -d /$to_home_root/${to_user} -c ${config_name} -t ${test_name}`
+
+# If we're using PCP start logging
+if [[ $to_use_pcp -eq 1 ]]; then
+        echo "Start PCP"
+       	start_pcp ${pcpdir}/ ${test_name} $pcp_cfg
+fi
+
+if test -f "$file"; then
 	#
-	os="`test_tools/detect_os`"
-	packages="gcc"
-	case "$os" in
-		"ubuntu")
-			packages="$packages,libnuma-dev"
-		;;
-		*) # RHEL based systems
-			packages="$packages,numactl-devel,numactl-libs"
-		;;
-	esac
-	echo "test_tools/package_tool --packages $packages --no_packages $to_no_pkg_install" > /tmp/pi_debug
-	test_tools/package_tool --packages $packages --no_packages $to_no_pkg_install
-
-
-	# Get PCP setup if we're using it
-	if [[ $to_use_pcp -eq 1 ]]; then
-	    	source $TOOLS_BIN/pcp/pcp_commands.inc
-	    	setup_pcp
-	    	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
-		pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
-	fi
-
+	# We have a parameters file to use, walk through each line.
 	#
-	# Check to see if we have a parameters file to use.
+	while IFS= read -r pig_opts
+	do
+		run_pig_test
+	done < "$file"
+else
 	#
-	file=`${curdir}/tools_bin/get_params_file -d /$to_home_root/${to_user} -c ${config_name} -t ${test_name}`
-
-	# If we're using PCP start logging
-	if [[ $to_use_pcp -eq 1 ]]; then
-	        echo "Start PCP"
-	       	start_pcp ${pcpdir}/ ${test_name} $pcp_cfg
-	fi
-
-	if test -f "$file"; then
-		#
-		# We have a parameters file to use, walk through each line.
-		#
-		while IFS= read -r pig_opts
-		do
-			run_pig_test
-		done < "$file"
-	else
-		#
-		# Run default test
-		#
-		run_pig_test 
-	fi
-
-	# If we're using PCP, stop logging
-	if [[ $to_use_pcp -eq 1 ]]; then
-	        echo "Stop PCP"
-	        stop_pcp
-	fi
-	
-	# Shutdown PCP and clean up after ourselves
-	if [[ $to_use_pcp -eq 1 ]]; then
-	    	shutdown_pcp
-	fi
-	
-	cd $run_dir
-	cd results_${test_name}_${to_tuned_setting} 
-	produce_results_info
-	cd ..
+	# Run default test
 	#
-	# Save the results for later.
-	#
-	if [[ $to_use_pcp -eq 1 ]]; then
-		cp -R ${pcpdir} results_${test_name}_${to_tuned_setting}
-	fi
-	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir results_${test_name}_${to_tuned_setting} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user
+	run_pig_test 
+fi
+
+# If we're using PCP, stop logging
+if [[ $to_use_pcp -eq 1 ]]; then
+        echo "Stop PCP"
+        stop_pcp
+fi
+
+# Shutdown PCP and clean up after ourselves
+if [[ $to_use_pcp -eq 1 ]]; then
+    	shutdown_pcp
+fi
+
+cd $run_dir
+cd results_${test_name}_${to_tuned_setting} 
+produce_results_info
+cd ..
+#
+# Save the results for later.
+#
+if [[ $to_use_pcp -eq 1 ]]; then
+	cp -R ${pcpdir} results_${test_name}_${to_tuned_setting}
+fi
+${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir results_${test_name}_${to_tuned_setting} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user

--- a/pig/run_pig.sh
+++ b/pig/run_pig.sh
@@ -93,8 +93,6 @@ fi
 # to_home_root: home directory
 # to_configuration: configuration information
 # to_times_to_run: number of times to run the test
-# to_pbench: Run the test via pbench
-# to_puser: User running pbench
 # to_run_label: Label for the run
 # to_user: User on the test system running the test
 # to_sys_type: for results info, basically aws, azure or local
@@ -229,13 +227,6 @@ run_pig_test()
 	popd > /dev/null
 }
 
-if [ $to_pbench -eq 1 ]; then
-	source ~/.bashrc
-
-	echo $TOOLS_BIN/execute_via_pbench --cmd_executing "$0" ${arguments} --test ${test_name} --spacing 11 --pbench_stats $to_pstats
-	$TOOLS_BIN/execute_via_pbench --cmd_executing "$0" ${arguments} --test ${test_name} --spacing 11 --pbench_stats $to_pstats
-else
-	#
 	# Ensure required packages are installed for compilation/linking
 	#
 	os="`test_tools/detect_os`"
@@ -278,4 +269,3 @@ else
 	# Save the results for later.
 	#
 	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir results_${test_name}_${to_tuned_setting} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user
-fi


### PR DESCRIPTION
# Description
- removes pbench references from README.md and add PCP
- updates build_run_pig.sh to work without pbench and instead use PCP

# Before/After Comparison
Before: the wrapper uses pbench
After: the wrapper uses pcp

# Clerical Stuff
This closes #18 https://github.com/redhat-performance/pig-wrapper/issues/20
Relates to JIRA: RPOPC-605 RPOPC-604