### PR TITLE
Fix tools_bin location

### DIFF
--- a/pig/run_pig.sh
+++ b/pig/run_pig.sh
@@ -229,7 +229,7 @@ run_pig_test()
 	popd > /dev/null
 }
 
-$TOOLS_BIN/package_tool --wrapper_config "${run_dir}/pig.json" --no_packages "$to_no_pkg_install"
+package_tool --wrapper_config "${run_dir}/pig.json"
 if [[ $? -ne 0 ]]; then
 	exit_out "package_tool reported failure installing dependencies."
 fi

--- a/pig/run_pig.sh
+++ b/pig/run_pig.sh
@@ -48,6 +48,7 @@ usage()
 #
 # Clone the repo that contains the common code and tools
 #
+export TOOLS_BIN="$HOME/test_tools"
 tools_git=https://github.com/redhat-performance/test_tools-wrappers
 
 found=0
@@ -75,8 +76,8 @@ done
 # Check to see if the test tools directory exists.  If it does, we do not need to
 # clone the repo.
 #
-if [ ! -d "test_tools" ]; then
-        git clone $tools_git test_tools
+if [ ! -d "$TOOLS_BIN" ]; then
+        git clone $tools_git $TOOLS_BIN
         if [ $? -ne 0 ]; then
                 echo pulling git $tools_git failed.
                 exit
@@ -101,7 +102,7 @@ fi
 # to_use_pcp: flag to indicate if pcp should be used
 #
 
-source test_tools/general_setup "$@"
+source $TOOLS_BIN/general_setup "$@"
 
 #
 # Define options
@@ -228,7 +229,7 @@ run_pig_test()
 	popd > /dev/null
 }
 
-test_tools/package_tool --wrapper_config "${run_dir}/pig.json" --no_packages "$to_no_pkg_install"
+$TOOLS_BIN/package_tool --wrapper_config "${run_dir}/pig.json" --no_packages "$to_no_pkg_install"
 if [[ $? -ne 0 ]]; then
 	exit_out "package_tool reported failure installing dependencies."
 fi
@@ -288,4 +289,4 @@ cd ..
 if [[ $to_use_pcp -eq 1 ]]; then
 	cp -R ${pcpdir} results_${test_name}_${to_tuned_setting}
 fi
-${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir results_${test_name}_${to_tuned_setting} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user
+${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --copy_dir results_${test_name}_${to_tuned_setting} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user


### PR DESCRIPTION
# Description
This PR anchors the TOOLS_BIN directory to `$HOME/test_tools`.  It also uses the package_tool alias to get all needed package flags in future.

# Before/After Comparison
## Before
test_tools would be placed in the current directory of the calling shell.

We would need to manage all package_tool flags within the wrapper

## After
test_tools now lives at $HOME/test_tools

general_setup would provide all the global package flags to package_tool

# Clerical Stuff
This closes #23 

Relates to JIRA: RPOPC-845
[run.log](https://github.com/user-attachments/files/25501001/run.log)
