### PR TITLE
Replace : with , in csv file

### DIFF
--- a/pig/run_pig.sh
+++ b/pig/run_pig.sh
@@ -187,14 +187,14 @@ produce_results_info()
 			continue
 		fi
 		value=`echo "scale=2;$cpu_total/$thread_total" | bc`
-		echo $thread_cnt:$value >> results_${test_name}.csv
+		echo $thread_cnt,$value >> results_${test_name}.csv
 		printf "%11s %11s\n" $thread_cnt $value >> results.txt
 		cpu_total=$cpus
 		thread_cnt=$threads
 		thread_total=$threads
 	done < "temp_data"
 	value=`echo "scale=2;$cpu_total/$thread_total" | bc`
-	echo $thread_cnt:$value >> results_${test_name}.csv
+	echo $thread_cnt,$value >> results_${test_name}.csv
 	printf "%11s %11s\n" $thread_cnt $value >> results.txt
 	thread_cnt=$threads
 	thread_total=$threads


### PR DESCRIPTION
# Description
Replaces the : field separator with a , in the csv file

# Before/After Comparison
Before: field separator is a : (old separator), needs to be a ',' else automation tools break.
After: Field separator is a ',' automation tools work properly.

# Clerical Stuff
This closes #27 

Relates to JIRA: RPOPC-1022

Testing:

Verified that , is now the field separator.


New csv file
# Test general meta start
# Test: pig
# Results version: 1.0
# Host: m5.xlarge
# Sys environ: aws
# Tuned: virtual-guest
# OS: 6.12.0-124.38.1.el10_1.x86_64
# Numa nodes: 1
# CPU family: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
# Number cpus: 4
# Memory: 15897856kB
# Test general meta end
#threads sched_eff
1,4.00
2,2.00
3,1.66
4,2.00
